### PR TITLE
fix: use correct dispatch event from @discordjs/ws WebSocketManager

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,9 @@ const policy = new Policy(cfg);
 const dc = new DiscordClient(token);
 
 // Gateway setup
-const intents = Number(process.env.GATEWAY_INTENTS ?? (1 << 0) /*Guilds*/ | (1 << 9) /*GuildMessages*/);
+const rawIntents = process.env.GATEWAY_INTENTS;
+const defaultIntents = (1 << 0) | (1 << 9); // Guilds | GuildMessages
+const intents = rawIntents ? Number(rawIntents) : defaultIntents;
 const gw = new GatewayManager(token, intents);
 gw.start();
 


### PR DESCRIPTION
The gateway wasn't receiving any events because `WebSocketManager` emits `dispatch`, not `event`. 

Also the payload structure is `{ data, shardId }` where `data` has the actual event fields (t, d, s, op), so we need to unwrap it.

Bonus fix: the default intents calculation had an operator precedence bug - `??` binds looser than `|`.