### PR TITLE
fix: block destructive Discord tools from generated surface

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,26 @@
+import typescriptEslint from '@typescript-eslint/eslint-plugin';
+import typescriptParser from '@typescript-eslint/parser';
+
+export default [
+  {
+    ignores: ['dist/**', 'node_modules/**', 'docs/.vitepress/**'],
+  },
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: typescriptParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': typescriptEslint,
+    },
+    rules: {
+      ...typescriptEslint.configs.recommended.rules,
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "test": "tsx --test src/*.test.ts",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "prepare": "npm run build",

--- a/src/generator.test.ts
+++ b/src/generator.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { DiscordClient } from './discord.js';
+import type { Policy } from './policy.js';
+import { generateTools } from './generator.js';
+
+test('generateTools excludes destructive Discord tools', () => {
+  const client = { getRest: () => ({}) } as DiscordClient;
+  const policy = {} as Policy;
+  const catalog = [
+    {
+      name: 'discord_delete_message',
+      method: 'DELETE' as const,
+      path: '/channels/:channel_id/messages/:message_id',
+      description: 'Delete a message',
+      schema: { type: 'object', properties: {} },
+    },
+    {
+      name: 'discord_get_channel',
+      method: 'GET' as const,
+      path: '/channels/:channel_id',
+      description: 'Get a channel',
+      schema: { type: 'object', properties: {} },
+    },
+  ];
+
+  const tools = generateTools(catalog, client, policy, {
+    packsEnabled: new Set(['CORE']),
+    defaultAllowedMentions: {},
+  });
+
+  assert.deepEqual(tools.map(({ entry }) => entry.name), ['discord_get_channel']);
+});

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -73,9 +73,19 @@ export function generateTools(catalog: CatalogEntry[], dc: DiscordClient, policy
 }): GeneratedTool[] {
   const rest = dc.getRest();
   const tools: GeneratedTool[] = [];
+  // Blocklist: dangerous tools that should never be exposed, regardless of pack
+  const BLOCKED_TOOLS = new Set([
+    'discord_delete_message',
+    'discord_bulk_delete_messages',
+    'discord_delete_channel',
+    'discord_delete_reactions_for_emoji',
+    'discord_clear_all_reactions',
+  ]);
+
   for (const entry of catalog) {
     const pack = entry.pack ?? 'CORE';
     if (!options.packsEnabled.has(pack)) continue;
+    if (BLOCKED_TOOLS.has(entry.name)) continue;
 
     // Build schema: path params + the schema's properties
     const pathParams = pickParamsForPath(entry.path);


### PR DESCRIPTION
## Summary
- exclude destructive message, channel, and reaction deletion tools from generated MCP tools
- add a regression test for the blocklist
- restore the ESLint 9 quality gate with a flat config

## Verification
- `npm run lint`
- `npm test` (1 passed)
- `npm run build`